### PR TITLE
Uses $set when updating collection

### DIFF
--- a/gantt-data.js
+++ b/gantt-data.js
@@ -150,7 +150,7 @@ function CollectionHandler(collection) {
 
         var savedItemData = this.findItem(item.id);
         if(savedItemData)
-            collection.update({_id: savedItemData._id}, item);
+            collection.update({_id: savedItemData._id}, { $set: item});
         else
             collection.insert(item);
     };


### PR DESCRIPTION
Uses $set to make the update. This means it will work with a published collection, also means it won't overwrite any extra fields that may have been added to the item
